### PR TITLE
Reference RNA counts with dollar

### DIFF
--- a/R/scrublet.R
+++ b/R/scrublet.R
@@ -36,7 +36,7 @@ scrublet_R <- function(seurat_obj, python_home = Sys.which("python"),
   reticulate::source_python(paste(system.file(package = "scrubletR"), "scrublet.py", sep = "/"))
 
   ## prepare the data
-  X <- as(Matrix::t(seurat_obj@assays$RNA@counts), "TsparseMatrix")
+  X <- as(Matrix::t(seurat_obj@assays$RNA$counts), "TsparseMatrix")
   i <- as.integer(X@i)
   j <- as.integer(X@j)
   val <- X@x


### PR DESCRIPTION
This commit fixes a bug where referencing the RNA assay counts would reach an error while referencing using the `@` operator